### PR TITLE
Make it usable as gem and add some options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kuberun (0.2.0)
+    kuberun (0.2.1)
       pastel (~> 0.8.0)
       thor (~> 1.2.1)
       tty-command (~> 0.10.1)
@@ -94,4 +94,4 @@ DEPENDENCIES
   rubocop (~> 0.58.0)
 
 BUNDLED WITH
-   2.3.20
+   2.3.19

--- a/exe/kuberun
+++ b/exe/kuberun
@@ -3,8 +3,9 @@
 
 lib_path = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
-require 'kuberun/cli'
 require 'kuberun'
+require 'kuberun/cli'
+
 
 Signal.trap('INT') do
   warn("\n#{caller.join("\n")}: interrupted")

--- a/lib/kuberun/cli.rb
+++ b/lib/kuberun/cli.rb
@@ -9,19 +9,7 @@ module Kuberun
   # @api public
   class CLI < Thor
     DEFAULT_OPTIONS_FOR_KUBECTL_OPTIONS = { type: :string, default: '', desc: 'See kubectl options' }.freeze
-    BASE_KUBECTL_OPTIONS = {
-      'certificate-authority': {},
-      'client-certificate': {},
-      'client-key': {},
-      'cluster': {},
-      'context': {},
-      'insecure-skip-tls-verify': {},
-      'kubeconfig': {},
-      'namespace': { aliases: :'-n' },
-      'token': {},
-      'v': { type: :numeric, default: 0, desc: 'Log level passed to kubectl' }
-    }.freeze
-    BASE_KUBECTL_OPTIONS.each do |option_name, hash|
+    ::Kubectl::OPTIONS.each do |option_name, hash|
       class_option option_name, DEFAULT_OPTIONS_FOR_KUBECTL_OPTIONS.merge(hash)
     end
     class_option :debug, type: :boolean, default: false, desc: 'Debug logging'

--- a/lib/kuberun/kubectl/exec.rb
+++ b/lib/kuberun/kubectl/exec.rb
@@ -14,11 +14,16 @@ class Kubectl
       @kubectl = kubectl
     end
 
-    def exec(pod:, command:)
-      old_state = `stty -g`
+    def exec(pod, options)
+      command = "#{kubectl_base_command('exec', resource: pod)} -it -- #{options['cluster-command']}"
 
-      PTY.spawn("#{kubectl_base_command('exec', resource: pod)} #{command}") do |out, inp, pid|
-        pty_process(out, inp, pid, old_state)
+      if options['pty']
+        old_state = `stty -g`
+        PTY.spawn(command) do |out, inp, pid|
+          pty_process(out, inp, pid, old_state)
+        end
+      else
+        system(command)
       end
     end
 


### PR DESCRIPTION
Make it usable as gem:

* Change load order and const setup to work outside of CLI

Add options:

* Add option to specify cluster command
* Add option to automatically use first pod
* Add option to autimatically clean pod after session
* Add option to skip auth check
* Add option to not use PTY (use `system` command instead)